### PR TITLE
Retry messages that fail with error: "pending"

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -148,7 +148,7 @@ module.exports = function (grunt) {
 
     exec: {
       appOpen: {
-        cmd: `~/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --load-and-launch-app="${pluginFolder}"`
+        cmd: `/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --load-and-launch-app="${pluginFolder}"`
       },
       checkPemSpecified: {
         cmd: function () {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "chrome-fresh",
   "version": "0.0.0",
   "main": "dist/scripts/app.bundled.js",
-  "dependencies": {},
+  "dependencies": {
+    "grunt-cli": "^1.3.2"
+  },
   "devDependencies": {
     "babel-preset-es2015": "^6.3.13",
     "babelify": "^7.2.0",
@@ -19,7 +21,6 @@
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-cssmin": "~0.9.0",
     "grunt-contrib-htmlmin": "~0.3.0",
-    "grunt-contrib-imagemin": "~0.7.1",
     "grunt-contrib-jshint": "~0.9.2",
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-contrib-watch": "~0.6.1",


### PR DESCRIPTION
Candidate fix for the LED flakiness and other connection instabilities. I was able to repro the issue _without_ Circuit Playground Express, just using a loopback USB Serial device:

![image](https://user-images.githubusercontent.com/413693/56397909-18118e00-61fb-11e9-81bf-4a74c91c9f12.png)

Adding retry logic when zero bytes were sent seems to fix the issue.